### PR TITLE
generate_auth.sh: Exit if password verify fails

### DIFF
--- a/generate_auth.sh
+++ b/generate_auth.sh
@@ -3,7 +3,8 @@ if [[ $# -eq 0 ]] ; then
     echo "Run the script with the required auth user and namespace for the secret: ${0} [user] [namespace]"
     exit 0
 fi
-printf "${1}:`openssl passwd -apr1`\n" >> ingress_auth.tmp
+PASSWORDHASH=$(openssl passwd -apr1) || exit
+printf "${1}:${PASSWORDHASH}\n" >> ingress_auth.tmp
 kubectl delete secret -n ${2} ingress-auth
 kubectl create secret generic ingress-auth --from-file=ingress_auth.tmp -n ${2}
 rm ingress_auth.tmp


### PR DESCRIPTION
I had a failed password verification in the `openssl passwd -apr1` call in *generate_auth.sh*. The script still deleted and recreated the `ingress-auth` secret, but with a blank password hash.

I could have used `set -e` at the start of the script to exit on any failures, but I suspect that it would be better to continue if there's a failure later in the script (if only to delete *ingress_auth.tmp*), so I've just made it exit if `openssl passwd -apr1` gives an error.